### PR TITLE
feat: sync tasks with supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,12 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Supabase
+
+This project uses [Supabase](https://supabase.com) to persist tasks. Define the following environment variables before running or deploying the app:
+
+```
+NEXT_PUBLIC_SUPABASE_URL=<your-supabase-url>
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-supabase-anon-key>
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "kanban-todo",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.56.0",
         "lucide-react": "^0.542.0",
         "next": "15.5.2",
         "react": "19.1.0",
@@ -978,6 +979,80 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
+      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.3.tgz",
+      "integrity": "sha512-rg3DmmZQKEVCreXq6Am29hMVe1CzemXyIWVYyyua69y6XubfP+DzGfLxME/1uvdgwqdoaPbtjBDpEBhqxq1ZwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.1.tgz",
+      "integrity": "sha512-edRFa2IrQw50kNntvUyS38hsL7t2d/psah6om6aNTLLcWem0R6bOUq7sk7DsGeSlNfuwEwWn57FdYSva6VddYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.11.0.tgz",
+      "integrity": "sha512-Y+kx/wDgd4oasAgoAq0bsbQojwQ+ejIif8uczZ9qufRHWFLMU5cODT+ApHsSrDufqUcVKt+eyxtOXSkeh2v9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.56.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.56.0.tgz",
+      "integrity": "sha512-XqwhHSyVnkjdliPN61CmXsmFGnFHTX2WDdwjG3Ukvdzuu3Trix+dXupYOQ3BueIyYp7B6t0yYpdQtJP2hIInyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.5",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.3",
+        "@supabase/realtime-js": "2.15.1",
+        "@supabase/storage-js": "^2.10.4"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1299,11 +1374,16 @@
       "version": "20.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
       "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.1.12",
@@ -1323,6 +1403,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -5813,6 +5902,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -5973,7 +6068,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -6019,6 +6113,22 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -6134,6 +6244,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.56.0",
     "lucide-react": "^0.542.0",
     "next": "15.5.2",
     "react": "19.1.0",

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { Plus, Trash2 } from "lucide-react";
+import { supabase } from "../lib/supabaseClient";
 
 type Task = {
   id: string;
@@ -13,49 +14,66 @@ type ColumnId = "todo" | "in_progress" | "done";
 
 type BoardState = Record<ColumnId, Task[]>;
 
-const STORAGE_KEY = "kanban-todo-v1";
+type TaskRow = {
+  id: string;
+  title: string;
+  status: ColumnId;
+  created_at: string;
+};
 
 function uid() {
   return Math.random().toString(36).slice(2, 9);
 }
 
-function useLocalBoard(initial: BoardState) {
-  const [data, setData] = useState<BoardState>(initial);
-
-  // Load
-  useEffect(() => {
-    try {
-      const raw = localStorage.getItem(STORAGE_KEY);
-      if (raw) setData(JSON.parse(raw));
-    } catch {}
-  }, []);
-
-  // Save
-  useEffect(() => {
-    try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
-    } catch {}
-  }, [data]);
-
-  return [data, setData] as const;
-}
-
 const initialData: BoardState = {
-  todo: [
-    { id: uid(), title: "Спробувати нову дошку", createdAt: Date.now() },
-    { id: uid(), title: "Додати перше завдання", createdAt: Date.now() },
-  ],
+  todo: [],
   in_progress: [],
   done: [],
 };
 
 export default function KanbanBoard() {
-  const [board, setBoard] = useLocalBoard(initialData);
+  const [board, setBoard] = useState<BoardState>(initialData);
   const [quickAdd, setQuickAdd] = useState<Record<ColumnId, string>>({
     todo: "",
     in_progress: "",
     done: "",
   });
+
+  // Load tasks from Supabase and subscribe to changes
+  useEffect(() => {
+    async function fetchTasks() {
+      const { data } = await supabase
+        .from<TaskRow>("tasks")
+        .select("id, title, status, created_at")
+        .order("created_at", { ascending: false });
+      if (data) {
+        const next: BoardState = { todo: [], in_progress: [], done: [] };
+        for (const t of data) {
+          next[t.status].push({
+            id: t.id,
+            title: t.title,
+            createdAt: Date.parse(t.created_at),
+          });
+        }
+        setBoard(next);
+      }
+    }
+
+    fetchTasks();
+
+    const channel = supabase
+      .channel("tasks-changes")
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "tasks" },
+        () => fetchTasks()
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, []);
 
   const columns = useMemo(
     () => [
@@ -66,30 +84,40 @@ export default function KanbanBoard() {
     []
   );
 
-  function addTask(col: ColumnId, title: string) {
+  async function addTask(col: ColumnId, title: string) {
     if (!title.trim()) return;
+    const task = { id: uid(), title: title.trim(), createdAt: Date.now() };
     setBoard((prev) => ({
       ...prev,
-      [col]: [{ id: uid(), title: title.trim(), createdAt: Date.now() }, ...prev[col]],
+      [col]: [task, ...prev[col]],
     }));
     setQuickAdd((q) => ({ ...q, [col]: "" }));
+    await supabase.from("tasks").insert({
+      id: task.id,
+      title: task.title,
+      status: col,
+      created_at: new Date(task.createdAt).toISOString(),
+    });
   }
 
-  function removeTask(col: ColumnId, id: string) {
+  async function removeTask(col: ColumnId, id: string) {
     setBoard((prev) => ({ ...prev, [col]: prev[col].filter((t) => t.id !== id) }));
+    await supabase.from("tasks").delete().eq("id", id);
   }
 
-  function moveTask(from: ColumnId, to: ColumnId, id: string, index?: number) {
+  async function moveTask(from: ColumnId, to: ColumnId, id: string, index?: number) {
     setBoard((prev) => {
       const source = [...prev[from]];
       const target = from === to ? source : [...prev[to]];
       const i = source.findIndex((t) => t.id === id);
       if (i === -1) return prev;
       const [task] = source.splice(i, 1);
-      const insertAt = typeof index === "number" ? Math.max(0, Math.min(index, target.length)) : target.length;
+      const insertAt =
+        typeof index === "number" ? Math.max(0, Math.min(index, target.length)) : target.length;
       target.splice(insertAt, 0, task);
       return { ...prev, [from]: from === to ? target : source, [to]: target } as BoardState;
     });
+    await supabase.from("tasks").update({ status: to }).eq("id", id);
   }
 
   function onDragStart(e: React.DragEvent<HTMLDivElement>, taskId: string, from: ColumnId) {
@@ -120,9 +148,9 @@ export default function KanbanBoard() {
           <a
             className="btn-ghost"
             href="#"
-            onClick={(e) => {
+            onClick={async (e) => {
               e.preventDefault();
-              localStorage.removeItem(STORAGE_KEY);
+              await supabase.from("tasks").delete().neq("id", "");
               location.reload();
             }}
           >

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+export const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);


### PR DESCRIPTION
## Summary
- add Supabase client and integrate task board with database
- persist task CRUD operations and reset via Supabase
- document required Supabase environment variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b18883a25c832e956f12c31c67e11c